### PR TITLE
Update sentry version

### DIFF
--- a/src/main/scala/co/cobli/sbt/sentry/SentryPlugin.scala
+++ b/src/main/scala/co/cobli/sbt/sentry/SentryPlugin.scala
@@ -188,7 +188,7 @@ object SentryPlugin extends AutoPlugin {
 
   override def projectSettings = {
     Seq(
-      sentryVersion := "1.7.22",
+      sentryVersion := "1.7.29",
       sentryAppRelease := version.value,
       sentryAppDist := "jvm",
       sentryAppPackages := Seq(organization.value),


### PR DESCRIPTION
On this new version there is a method `isInitialized` that we can use on readiness routes to check Sentry health.
PR that implements the method: https://github.com/getsentry/sentry-java/pull/784