### PR TITLE
publish when a tag is applyed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ definitions:
     branches:
       only: master
     tags:
-      ignore: /.*/
+      only: /.*/
   multi_hash_args: &multi_hash_args
     in-files: "build.sbt project/build.properties project/plugins.sbt"
     out-file: /tmp/sbt-dependencies-checksum


### PR DESCRIPTION
This restore a Travis behavior lost on CircleCI migration that publishes this package at [every tag](https://github.com/Cobliteam/sbt-sentry/blob/5fb162e649691a790773d4bdd43a4fad9bccbd10/.travis.yml#L19)